### PR TITLE
Update LiquidityContainer.js

### DIFF
--- a/src/containers/liquidity/LiquidityContainer.js
+++ b/src/containers/liquidity/LiquidityContainer.js
@@ -261,7 +261,7 @@ const LiquidityContainer = (props) => {
               ...toValues,
               amount: reduceBalance(
                 fromValues.amount / pact.ratio,
-                fromValues.precision
+                toValues.precision
               ),
             })
           );
@@ -301,7 +301,7 @@ const LiquidityContainer = (props) => {
               ...fromValues,
               amount: reduceBalance(
                 toValues.amount * pact.ratio,
-                toValues.precision
+                fromValues.precision
               ),
             })
           );


### PR DESCRIPTION
The precision is taken from the wrong coin. This corrects the typo. Fixes the dreaded precision error.